### PR TITLE
Updates to support moving to checkstyle v8.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Checkstyle can be enabled in Java projects with Maven using the [Maven Checkstyl
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-checkstyle-plugin</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
     <executions>
         <execution>
             <id>verify-style</id>
@@ -49,7 +49,7 @@ Checkstyle can be enabled in Java projects with Maven using the [Maven Checkstyl
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>8.29</version>
         </dependency>
     </dependencies>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -16,30 +16,30 @@
     <developer>
       <id>awoods</id>
       <name>Andrew Woods</name>
-      <email>awoods @ (domain of organization url)</email>
-      <organization>DuraSpace</organization>
-      <organizationUrl>http://www.duraspace.org/</organizationUrl>
+      <email>andrew.woods @ (domain of organization url)</email>
+      <organization>LYRASIS</organization>
+      <organizationUrl>https://lyrasis.org</organizationUrl>
     </developer>
     <developer>
       <id>bbranan</id>
       <name>Bill Branan</name>
-      <email>bbranan @ (domain of organization url)</email>
-      <organization>DuraSpace</organization>
-      <organizationUrl>http://www.duraspace.org/</organizationUrl>
+      <email>bill.branan @ (domain of organization url)</email>
+      <organization>LYRASIS</organization>
+      <organizationUrl>https://lyrasis.org</organizationUrl>
     </developer>
     <developer>
       <id>dbernstein</id>
       <name>Danny Bernstein</name>
-      <email>dbernstein @ (domain of organization url)</email>
-      <organization>DuraSpace</organization>
-      <organizationUrl>http://www.duraspace.org/</organizationUrl>
+      <email>daniel.bernstein @ (domain of organization url)</email>
+      <organization>LYRASIS</organization>
+      <organizationUrl>https://lyrasis.org</organizationUrl>
     </developer>
     <developer>
       <id>tdonohue</id>
       <name>Tim Donohue</name>
-      <email>tdonohue @ (domain of organization url)</email>
-      <organization>DuraSpace</organization>
-      <organizationUrl>http://www.duraspace.org/</organizationUrl>
+      <email>tim.donohue @ (domain of organization url)</email>
+      <organization>LYRASIS</organization>
+      <organizationUrl>https://lyrasis.org</organizationUrl>
     </developer>
   </developers>
 

--- a/src/main/resources/duraspace-checkstyle/checkstyle.xml
+++ b/src/main/resources/duraspace-checkstyle/checkstyle.xml
@@ -37,17 +37,18 @@
          with @SuppressWarnings. See also SuppressWarningsHolder below -->
     <module name="SuppressWarningsFilter" />
 
+    <!-- Maximum line length is 120 characters -->
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="120"/>
+        <!-- Make exceptions for package names, imports, URLs, JavaDoc {@link} tags,
+             and very long method names -->
+        <property name="ignorePattern"
+                  value="^package.*|^import.*|http://|https://|@link"/>
+    </module>
+
     <!-- Check individual Java source files for specific rules -->
     <module name="TreeWalker">
-        <!-- Maximum line length is 120 characters -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <!-- Make exceptions for package names, imports, URLs, JavaDoc {@link} tags,
-                 and very long method names -->
-            <property name="ignorePattern"
-                      value="^package.*|^import.*|http://|https://|@link"/>
-        </module>
-
         <!-- Highlight any TODO or FIXME comments in info messages -->
         <module name="TodoComment">
             <property name="severity" value="info"/>
@@ -95,11 +96,8 @@
         <module name="JavadocMethod">
             <!-- All public methods MUST HAVE Javadocs -->
             <property name="scope" value="public"/>
-            <!-- Allow RuntimeExceptions to be undeclared -->
-            <property name="allowUndeclaredRTE" value="true"/>
             <!-- Allow params, throws and return tags to be optional -->
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
         </module>
 


### PR DESCRIPTION
Reason to upgrade is vulnerability listed here: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9658

Pulls the LineLength module out from under the TreeWalker module due to change in checkstyle: https://github.com/checkstyle/checkstyle/issues/2116

Removes properties from JavadocMethod that are no longer supported: https://github.com/checkstyle/checkstyle/issues/7329

Note: Validation of import statements based on the CustomImportOrder module appears to be more strict in version 8.29 of checkstyle. This may result in build failures.